### PR TITLE
Fix drag drop between tiers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   useSensor,
   useSensors,
   DragEndEvent,
+  useDroppable,
 } from '@dnd-kit/core';
 import {
   arrayMove,
@@ -79,11 +80,23 @@ export default function App() {
 }
 
 function Tier({ id, title, items }: { id: string; title: string; items: string[] }) {
+  const { setNodeRef } = useDroppable({ id });
+
   return (
     <div>
       <h3>{title}</h3>
       <SortableContext items={items} strategy={rectSortingStrategy}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, minHeight: 50, padding: 10, background: '#f0f0f0' }}>
+        <div
+          ref={setNodeRef}
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 8,
+            minHeight: 50,
+            padding: 10,
+            background: '#f0f0f0',
+          }}
+        >
           {items.map(item => (
             <Item key={item} id={item} />
           ))}


### PR DESCRIPTION
## Summary
- make tier containers droppable so anime can be moved between tiers

## Testing
- `npm run build` *(fails: vite not executable)*
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6840141dd8b08323823d89976bb4547d